### PR TITLE
Provide Test Nodes

### DIFF
--- a/qrb_ros_video/CMakeLists.txt
+++ b/qrb_ros_video/CMakeLists.txt
@@ -16,9 +16,16 @@ find_package(rclcpp_components REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
 find_package(qrb_video_v4l2_lib REQUIRED)
 
+# Add GStreamer dependency
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(gstreamer REQUIRED gstreamer-1.0 gstreamer-base-1.0 
+                                    gstreamer-video-1.0 gstreamer-app-1.0 
+                                    gstreamer-allocators-1.0 gstreamer-pbutils-1.0)
+
 include_directories(std_msgs_INCLUDE_DIRS)
 include_directories(sensor_msgs_INCLUDE_DIRS)
 include_directories(rclcpp_components_INCLUDE_DIRS)
+include_directories(gstreamer_INCLUDE_DIRS)
 
 ament_auto_find_build_dependencies()
   
@@ -45,6 +52,43 @@ rclcpp_components_register_nodes(
   "qrb_ros::video::PerfDecoder"
   "qrb_ros::video::Encoder"
   "qrb_ros::video::PerfEncoder"
+)
+
+# Add test components library
+ament_auto_add_library(test_components SHARED 
+  test/src/src_node.cpp 
+  test/src/sink_node.cpp
+)
+target_include_directories(test_components PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/include>
+  $<INSTALL_INTERFACE:test/include>)
+target_compile_features(test_components PUBLIC cxx_std_17)
+ament_target_dependencies(
+  test_components
+  "std_msgs"
+  "sensor_msgs"
+  "rclcpp"
+  "rclcpp_components"
+  "gstreamer"
+)
+target_link_libraries(test_components ${gstreamer_LIBRARIES})
+target_link_directories(test_components PRIVATE $<TARGET_LINKER_FILE_DIR:v4l2codecs>)
+
+# Register test components
+rclcpp_components_register_nodes(
+  test_components
+  "qrb_ros::video::ImageWriter"
+  "qrb_ros::video::ImageReader"
+  "qrb_ros::video::CompressedReader"
+  "qrb_ros::video::CompressedWriter"
+)
+
+# Install executables and libraries
+install(TARGETS
+  test_components
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
 ament_auto_package(INSTALL_TO_SHARE launch)

--- a/qrb_ros_video/include/video_node.hpp
+++ b/qrb_ros_video/include/video_node.hpp
@@ -103,6 +103,7 @@ protected:
     std::for_each(latency_.begin(), latency_.end(), [&](auto & sample) {
       if (sample.second[fbd] == 0) {
         num[fbd]--;
+        num[etb]--;
         return;
       }
       uint64_t input_latency = sample.second[etb] - sample.first;

--- a/qrb_ros_video/launch/decoder_launch.py
+++ b/qrb_ros_video/launch/decoder_launch.py
@@ -33,8 +33,8 @@ def generate_launch_description():
                 namespace='playback_ns',
                 name='writer_node',
                 parameters=[{
-                    'url': "/data/1920_1080_nv12.yuv",
-                    'format': 'mp4',
+                    'url': "/dev/null",
+                    'format': "nv12",
                 }],
                 extra_arguments=[{"use_intra_process_comms": True}],
                 remappings=[("input", "writer_node/raw_image")]
@@ -45,10 +45,10 @@ def generate_launch_description():
                 namespace='playback_ns',
                 name='reader_node',
                 parameters=[{
-                    'url': "/data/1920_1080_nv12.h264",
-                    'pixel-format': "h264",
+                    'url': "/data/1920_1080.mp4",
+                    'format': "mp4",
                     'width': "1920",
-                    'hight': "1080",
+                    'height': "1080",
                     'framerate': "30",
                 }],
                 extra_arguments=[{"use_intra_process_comms": True}],

--- a/qrb_ros_video/launch/encoder_launch.py
+++ b/qrb_ros_video/launch/encoder_launch.py
@@ -22,21 +22,6 @@ def generate_launch_description():
         executable='component_container',
         composable_node_descriptions=[
             ComposableNode(
-                package='qrb_ros_camera',
-                plugin='qrb_ros::camera::CameraNode',
-                namespace='recording_ns',
-                name='camera_node',
-                parameters=[{
-                    'camera_info_path': camera_info_path,
-                    'fps': 30,
-                    'width': 1920,
-                    'height': 1080,
-                    'cameraId': 1,
-                }],
-                extra_arguments=[{"use_intra_process_comms": True}],
-                remappings=[('image', 'encoder_node/input')],
-            ),
-            ComposableNode(
                 package='qrb_ros_video',
                 plugin='qrb_ros::video::Encoder',
                 namespace='recording_ns',
@@ -63,13 +48,28 @@ def generate_launch_description():
                 namespace='recording_ns',
                 name='writer_node',
                 parameters=[{
-                    'url': "/data/1920_1080_nv12.h264",
-                    'format': "h264",
+                    'url': "/data/1920_1080_nv12.mp4",
+                    'format': "mp4",
                 }],
                 extra_arguments=[{"use_intra_process_comms": True}],
                 remappings=[("input", "writer_node/compressed_image"),
                             ]
-            )
+            ),
+            ComposableNode(
+                package='qrb_ros_video',
+                plugin='qrb_ros::video::ImageReader',
+                namespace='recording_ns',
+                name='reader_node',
+                parameters=[{
+                    'url': "/data/1920_1080_nv12.yuv",
+                    'format': "nv12",
+                    'width': "1920",
+                    'height': "1080",
+                    'framerate': "30",
+                }],
+                extra_arguments=[{"use_intra_process_comms": True}],
+                remappings=[("output", "encoder_node/input")]
+            ),
         ],
         output='screen',
     )

--- a/qrb_ros_video/package.xml
+++ b/qrb_ros_video/package.xml
@@ -8,6 +8,7 @@
   <license>BSD-3-Clause-Clear</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
@@ -17,6 +18,12 @@
   <depend>ros2launch</depend>
   <depend>qrb_video_v4l2_lib</depend>
   <depend>qrb_ros_transport_image_type</depend>
+
+  <build_depend>libgstreamer1.0-dev</build_depend>
+  <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
+
+  <exec_depend>libgstreamer1.0-0</exec_depend>
+  <exec_depend>libgstreamer-plugins-base1.0-0</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/qrb_ros_video/src/video_encoder.cpp
+++ b/qrb_ros_video/src/video_encoder.cpp
@@ -119,6 +119,9 @@ protected:
         new lib_mem_dmabuf::DmaBuffer(dup(fd), image_size), destroy_callback);
     msg->encoding = this->format;
     this->publisher->publish(std::move(msg));
+    RCLCPP_DEBUG(this->get_logger(),
+        "[%s]: transport::type::Image, format[%s] size[%zd] ts[%ld.%ld]", __func__,
+        this->format.c_str(), image_size, item->timestamp.tv_sec, item->timestamp.tv_usec);
     return true;
   }
 
@@ -142,8 +145,8 @@ protected:
     msg->format = this->format;
     this->publisher->publish(std::move(msg));
     RCLCPP_DEBUG(this->get_logger(),
-        "[%s]: sensor_msgs::msg::CompressedImage, format[%d] size[%zd] ts[%ld.%ld]", __func__,
-        this->format, image_size, item->timestamp.tv_sec, item->timestamp.tv_sec);
+        "[%s]: sensor_msgs::msg::CompressedImage, format[%s] size[%zd] ts[%ld.%ld]", __func__,
+        this->format.c_str(), image_size, item->timestamp.tv_sec, item->timestamp.tv_usec);
     return true;
   }
 

--- a/qrb_ros_video/test/README.md
+++ b/qrb_ros_video/test/README.md
@@ -1,0 +1,68 @@
+# Test Nodes for qrb_ros_video
+
+This directory contains test nodes for the qrb_ros_video package, which provide GStreamer-based source and sink nodes for testing the video hardware acceleration capabilities. The nodes support both CompressedImage and custom Image message types.
+
+## Available Nodes
+
+### Source Nodes
+
+Test nodes that act as input sources for the Encoder/Decoder. They extract data from a GStreamer pipeline using GstAppSink and publish it to a ROS2 topic.
+
+#### CompressedReader
+- **Topic**: `output`
+- **Message Type**: `sensor_msgs/msg/CompressedImage`
+- **GStreamer Pipelines**:
+  - H264 mode: `filesrc ! h264parse ! stream-format=byte-stream,alignment=au ! appsink`
+  - H265 mode: `filesrc ! h265parse ! stream-format=byte-stream,alignment=au ! appsink`
+  - MP4 mode: `filesrc ! qtdemux ! h264parse ! stream-format=byte-stream,alignment=au ! appsink`
+
+#### ImageReader
+- **Topic**: `output`
+- **Message Type**: `qrb_ros::transport::type::Image`
+- **GStreamer Pipelines**:
+  - Raw mode: `filesrc ! rawvideoparse ! appsink`
+
+### Sink Nodes
+
+Test nodes that act as output sinks for the Encoder/Decoder. They receive data from a ROS2 topic and send it to a GStreamer pipeline using GstAppSrc.
+
+#### CompressedWriter
+- **Topic**: `input`
+- **Message Type**: `sensor_msgs/msg/CompressedImage`
+- **GStreamer Pipelines**:
+  - MP4 mode: `appsrc ! h264parse ! qtmux ! filesink`
+  - Raw mode: `appsrc ! filesink`
+
+#### ImageWriter
+- **Topic**: `input`
+- **Message Type**: `qrb_ros::transport::type::Image`
+- **GStreamer Pipelines**:
+  - Raw mode: `appsrc ! filesink`
+
+## Parameters
+
+Common parameters for all nodes:
+
+- `format`: Pipeline format ("raw" or "mp4")
+- `width`: Frame width
+- `height`: Frame height
+- `framerate`: Frame rate (e.g., "30/1")
+- `log-level`: Logging level ("debug", "info", "warn")
+
+Source node specific parameters:
+
+- `url`: Path to input file
+- `duration`: Duration for source ("1d", "2h", "34m56s")
+
+Sink node specific parameters:
+
+- `url`: Path to output file
+
+## Notes
+
+- Make sure the input file exists and is accessible
+- The output file will be created in the specified location
+- Both nodes will output debug information to help with troubleshooting
+- The raw mode assumes raw video input (NV12 format)
+- The mp4 mode assumes H.264 encoded input
+- The ImageReader/Writer nodes use DMA buffers for efficient memory handling 

--- a/qrb_ros_video/test/include/base_node.hpp
+++ b/qrb_ros_video/test/include/base_node.hpp
@@ -1,0 +1,245 @@
+/*
+**************************************************************************************************
+* Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+* SPDX-License-Identifier: BSD-3-Clause-Clear
+**************************************************************************************************
+*/
+
+#ifndef QRB_ROS_VIDEO_TEST_BASE_NODE_HPP_
+#define QRB_ROS_VIDEO_TEST_BASE_NODE_HPP_
+
+#include <gst/gst.h>
+#include <gst/pbutils/pbutils.h>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace qrb_ros
+{
+namespace video
+{
+
+/**
+ * @brief Base node template class for GStreamer-based ROS nodes
+ */
+class BaseNode : public rclcpp::Node
+{
+public:
+  explicit BaseNode(const std::string & node_name, const rclcpp::NodeOptions & options)
+    : Node(node_name, options)
+    , format_(this->declare_parameter("format", "h264"))
+    , width_(this->declare_parameter("width", "640"))
+    , height_(this->declare_parameter("height", "480"))
+    , framerate_(this->declare_parameter("framerate", "30/1"))
+    , log_level_(this->declare_parameter("log-level", "warning"))
+    , url_(this->declare_parameter("url", ""))
+  {
+    // Initialize GStreamer
+    if (!gst_is_initialized()) {
+      gst_init(nullptr, nullptr);
+    }
+
+    auto pos = framerate_.find_first_of('/');
+    std::string denominator = "1";
+    if (pos != std::string::npos) {
+      denominator = framerate_.substr(pos + 1);
+    }
+    std::string numerator = framerate_.substr(0, pos);
+    fps_ = std::stof(numerator) / std::stof(denominator);
+
+    // Set ROS Node log level
+    auto log_level = rclcpp::Logger::Level::Warn;
+    if (log_level_ == "info") {
+      log_level = rclcpp::Logger::Level::Info;
+    } else if (log_level_ == "debug") {
+      log_level = rclcpp::Logger::Level::Debug;
+    }
+
+    get_logger().set_level(log_level);
+  }
+
+  virtual ~BaseNode() = default;
+
+protected:
+  /**
+   * @brief Setup the GStreamer pipeline
+   */
+  virtual void setup_pipeline() = 0;
+
+  // Common logging utility
+  void log_pipeline_creation(const std::string & pipeline_str)
+  {
+    RCLCPP_WARN(this->get_logger(), "Creating pipeline: %s", pipeline_str.c_str());
+  }
+
+  bool discover_pipeline()
+  {
+    if (url_.empty()) {
+      RCLCPP_ERROR(this->get_logger(), "No URL provided for file discovery");
+      return false;
+    }
+
+    // Discover the pipeline based on the format
+    if (format_ == "mp4") {
+      RCLCPP_INFO(this->get_logger(), "Discovering video codec from MP4 file: %s", url_.c_str());
+
+      // Create a proper URI if file path is provided
+      std::string uri = url_;
+      if (uri.find("://") == std::string::npos) {
+        // Assume it's a file path and convert to URI
+        uri = "file://" + uri;
+      }
+
+      // Create a new discoverer with 2-second timeout
+      GstDiscoverer * discoverer = gst_discoverer_new(2 * GST_SECOND, nullptr);
+      if (!discoverer) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to create GstDiscoverer");
+        return false;
+      }
+
+      // Attempt to discover the URI
+      GError * error = nullptr;
+      GstDiscovererInfo * info = gst_discoverer_discover_uri(discoverer, uri.c_str(), &error);
+
+      if (error) {
+        RCLCPP_ERROR(this->get_logger(), "Discovery error: %s", error->message);
+        g_error_free(error);
+        gst_object_unref(discoverer);
+        return false;
+      }
+
+      if (!info) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to discover URI: %s", uri.c_str());
+        gst_object_unref(discoverer);
+        return false;
+      }
+
+      // Check if discovery result is valid
+      GstDiscovererResult result = gst_discoverer_info_get_result(info);
+      if (result != GST_DISCOVERER_OK) {
+        RCLCPP_ERROR(this->get_logger(), "Discovery failed: %d", result);
+        gst_discoverer_info_unref(info);
+        gst_object_unref(discoverer);
+        return false;
+      }
+
+      // Extract video streams information
+      GList * list = gst_discoverer_info_get_video_streams(info);
+      if (!list) {
+        RCLCPP_ERROR(this->get_logger(), "No video streams found in the file");
+        gst_discoverer_info_unref(info);
+        gst_object_unref(discoverer);
+        return false;
+      }
+
+      bool found_stream = false;
+      // Extract information from the first video stream
+      for (GList * item = list; item != nullptr; item = item->next) {
+        GstDiscovererStreamInfo * stream_info = GST_DISCOVERER_STREAM_INFO(item->data);
+        if (GST_IS_DISCOVERER_VIDEO_INFO(stream_info)) {
+          GstDiscovererVideoInfo * video_info = GST_DISCOVERER_VIDEO_INFO(stream_info);
+
+          // Get codec information from caps
+          GstCaps * caps = gst_discoverer_stream_info_get_caps(stream_info);
+          if (caps) {
+            gchar * caps_str = gst_caps_to_string(caps);
+            RCLCPP_INFO(this->get_logger(), "Video caps: %s", caps_str);
+            g_free(caps_str);
+
+            // Extract codec from caps if possible
+            const GstStructure * structure = gst_caps_get_structure(caps, 0);
+            if (structure) {
+              const gchar * codec_name = gst_structure_get_name(structure);
+              if (codec_name) {
+                if (g_str_has_suffix(codec_name, "h264")) {
+                  pixel_format_ = "h264";
+                } else if (g_str_has_suffix(codec_name, "h265") ||
+                           g_str_has_suffix(codec_name, "hevc")) {
+                  pixel_format_ = "h265";
+                } else {
+                  pixel_format_ = codec_name;
+                }
+                RCLCPP_INFO(this->get_logger(), "Detected codec: %s", pixel_format_.c_str());
+              }
+            }
+            gst_caps_unref(caps);
+          }
+
+          // Get resolution and framerate
+          width_ = std::to_string(gst_discoverer_video_info_get_width(video_info));
+          height_ = std::to_string(gst_discoverer_video_info_get_height(video_info));
+
+          gint fps_num = gst_discoverer_video_info_get_framerate_num(video_info);
+          gint fps_denom = gst_discoverer_video_info_get_framerate_denom(video_info);
+
+          // Avoid division by zero
+          if (fps_denom > 0) {
+            framerate_ = std::to_string(fps_num) + "/" + std::to_string(fps_denom);
+            fps_ = static_cast<float>(fps_num) / static_cast<float>(fps_denom);
+          }
+
+          RCLCPP_INFO(this->get_logger(), "Video properties: %sx%s @ %s fps", width_.c_str(),
+              height_.c_str(), framerate_.c_str());
+
+          found_stream = true;
+          break;  // We only need information from the first video stream
+        }
+      }
+
+      g_list_free(list);
+      gst_discoverer_info_unref(info);
+      gst_object_unref(discoverer);
+
+      if (!found_stream) {
+        RCLCPP_ERROR(this->get_logger(), "No valid video stream found in the file");
+        return false;
+      }
+
+      RCLCPP_INFO(this->get_logger(), "Successfully discovered video information");
+      return true;
+    }
+
+    // For non-MP4 formats, we assume the format is correctly specified
+    RCLCPP_INFO(this->get_logger(), "Using specified format: %s", format_.c_str());
+    return true;
+  }
+
+  // Common error handling for pipeline creation
+  bool create_pipeline(const std::string & pipeline_str)
+  {
+    GError * error = nullptr;
+
+    log_pipeline_creation(pipeline_str);
+
+    pipeline_ = gst_parse_launch(pipeline_str.c_str(), &error);
+
+    if (error) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to create pipeline: %s", error->message);
+      g_error_free(error);
+      return false;
+    }
+
+    return true;
+  }
+
+  std::string format_;
+  std::string pixel_format_;
+  std::string width_;
+  std::string height_;
+  std::string framerate_;
+  std::string log_level_;
+  std::string url_;
+  float fps_ = 30.0f;
+  GstElement * pipeline_ = nullptr;
+};
+
+}  // namespace video
+}  // namespace qrb_ros
+
+#endif  // QRB_ROS_VIDEO_TEST_BASE_NODE_HPP_

--- a/qrb_ros_video/test/src/sink_node.cpp
+++ b/qrb_ros_video/test/src/sink_node.cpp
@@ -1,0 +1,390 @@
+/*
+**************************************************************************************************
+* Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+* SPDX-License-Identifier: BSD-3-Clause-Clear
+**************************************************************************************************
+*/
+
+#include <gst/allocators/gstdmabuf.h>
+#include <gst/app/gstappsrc.h>
+#include <gst/gst.h>
+#include <gst/video/gstvideometa.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "base_node.hpp"
+#include "qrb_ros_transport_image_type/image.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "sensor_msgs/msg/compressed_image.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+using namespace std::chrono_literals;
+
+namespace qrb_ros
+{
+namespace video
+{
+
+// Forward declarations of specialized classes for registration
+class CompressedWriter;
+class ImageWriter;
+
+/**
+ * @brief Base sink node template class for different message types
+ * @tparam MessageT The message type to subscribe to
+ */
+template <typename MessageT>
+class SinkNodeBase : public BaseNode
+{
+public:
+  explicit SinkNodeBase(const std::string & node_name, const rclcpp::NodeOptions & options)
+    : BaseNode(node_name, options), frame_counter_(0)
+  {
+    // Create subscription for input data - specific callback will be set by
+    // derived class
+    setup_subscription();
+  }
+
+  ~SinkNodeBase()
+  {
+    // Send EOS (End of Stream) and wait for pipeline to process it
+    if (app_src_ && pipeline_) {  // Ensure both app_src_ and pipeline_ are valid
+      GstFlowReturn ret = gst_app_src_end_of_stream(app_src_);
+      if (ret != GST_FLOW_OK) {
+        RCLCPP_WARN(this->get_logger(), "gst_app_src_end_of_stream() failed with %s",
+            gst_flow_get_name(ret));
+      } else {
+        RCLCPP_INFO(this->get_logger(), "EOS sent to appsrc. Waiting for EOS message on the "
+                                        "bus...");
+
+        GstBus * bus = gst_element_get_bus(pipeline_);
+        if (bus) {
+          // Wait for EOS or ERROR message, with a timeout (e.g., 5 seconds)
+          // GST_CLOCK_TIME_NONE can be used for an indefinite wait, but a timeout is safer.
+          GstMessage * msg = gst_bus_timed_pop_filtered(bus, 5 * GST_SECOND,
+              static_cast<GstMessageType>(GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+
+          if (msg) {
+            if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_EOS) {
+              RCLCPP_INFO(this->get_logger(),
+                  "EOS message received from pipeline. Stream ended gracefully.");
+            } else if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_ERROR) {
+              GError * err = nullptr;
+              gchar * debug_info = nullptr;
+              gst_message_parse_error(msg, &err, &debug_info);
+              RCLCPP_ERROR(this->get_logger(),
+                  "Error message received from pipeline during EOS: %s. Debug: %s",
+                  err ? err->message : "Unknown error", debug_info ? debug_info : "None");
+              if (err)
+                g_error_free(err);
+              if (debug_info)
+                g_free(debug_info);
+            }
+            gst_message_unref(msg);
+          } else {
+            RCLCPP_WARN(this->get_logger(),
+                "Timeout waiting for EOS message on the bus. Pipeline might not have processed EOS "
+                "completely.");
+          }
+          gst_object_unref(bus);
+        } else {
+          RCLCPP_ERROR(this->get_logger(), "Failed to get pipeline bus to wait for EOS.");
+          // Fallback to a simple sleep if bus is not available, though this is less reliable.
+          std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+      }
+      gst_element_set_state(pipeline_, GST_STATE_NULL);
+      gst_object_unref(pipeline_);
+      pipeline_ = nullptr;
+    } else {
+      if (!app_src_)
+        RCLCPP_WARN(this->get_logger(), "app_src_ is null in destructor, cannot send EOS.");
+      if (!pipeline_)
+        RCLCPP_WARN(
+            this->get_logger(), "pipeline_ is null in destructor, cannot wait for EOS on bus.");
+    }
+
+    // Base class (BaseNode) destructor will be called next and should handle
+    // setting the pipeline to GST_STATE_NULL and unreffing it.
+    // gst_object_unref(app_src_);
+    // app_src_ = nullptr;
+    RCLCPP_WARN(this->get_logger(), "SinkNodeBase destructor finished.");
+  }
+
+protected:
+  // Setup the subscription for the specific message type
+  virtual void setup_subscription()
+  {
+    subscription_ = this->create_subscription<MessageT>(
+        "input", 10, std::bind(&SinkNodeBase::handle_message, this, std::placeholders::_1));
+  }
+
+  virtual void handle_message(const std::shared_ptr<MessageT> msg) { this->process_message(msg); }
+
+  // Method to extract data from specific message type - to be implemented by
+  // derived classes
+  virtual GstBuffer * extract_data(const std::shared_ptr<MessageT> & msg) = 0;
+
+  void process_message(const std::shared_ptr<MessageT> & msg)
+  {
+    // Extract data from the message
+    GstBuffer * buffer = extract_data(msg);
+    if (!buffer) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to extract data from message");
+      return;
+    }
+
+    RCLCPP_DEBUG(this->get_logger(), "Received frame of size: %zu bytes with timestamp %ld",
+        gst_buffer_get_size(buffer), GST_BUFFER_PTS(buffer));
+
+    setup_pipeline();
+
+    // Push the buffer into appsrc
+    GstFlowReturn ret = gst_app_src_push_buffer(app_src_, buffer);
+    if (ret != GST_FLOW_OK) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to push buffer to GStreamer pipeline: %d", ret);
+    } else {
+      frame_counter_++;
+      RCLCPP_DEBUG(this->get_logger(), "Pushed frame %ld to pipeline", frame_counter_);
+    }
+  }
+
+  const std::map<std::string, std::function<std::string()>> pipeline_template = {
+    { "mp4",
+        [this]() {
+          // Efficient string construction using std::ostringstream
+          std::ostringstream oss;
+          oss << "appsrc name=src ! " << pixel_format_
+              << "parse ! qtmux ! filesink sync=false location=" << url_;
+
+          return oss.str();
+        } },
+    { "raw",
+        [this]() {
+          std::ostringstream oss;
+          oss << "appsrc name=src ! filesink sync=false "
+                 "location="
+              << url_;
+          return oss.str();
+        } },
+  };
+
+  void setup_pipeline() override
+  {
+    if (pipeline_ != nullptr) {
+      return;
+    }
+    std::string pipeline_str;
+    try {
+      pipeline_str = pipeline_template.at(format_)();
+    } catch (const std::out_of_range & e) {
+      if (format_ == "h264" || format_ == "h265" || format_ == "nv12") {
+        pipeline_str = pipeline_template.at("raw")();
+      } else {
+        RCLCPP_ERROR(this->get_logger(), "Invalid format: %s. Use 'mp4' or 'raw'", format_.c_str());
+        return;
+      }
+    }
+
+    if (!create_pipeline(pipeline_str)) {
+      return;
+    }
+
+    // Get the appsrc element
+    GstElement * src = gst_bin_get_by_name(GST_BIN(pipeline_), "src");
+    if (!src) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to get appsrc element");
+      return;
+    }
+
+    // Configure appsrc
+    app_src_ = GST_APP_SRC(src);
+    gst_app_src_set_stream_type(app_src_, GST_APP_STREAM_TYPE_STREAM);
+    gst_app_src_set_emit_signals(app_src_, TRUE);
+    gst_app_src_set_max_bytes(app_src_, 0);  // No limit on buffer size
+    g_object_set(G_OBJECT(app_src_), "is-live", TRUE, NULL);
+    g_object_set(G_OBJECT(app_src_), "do-timestamp", TRUE, NULL);
+
+    // Set caps based on mode
+    GstCaps * caps;
+    std::map<std::string, std::string> mime_mapping = { { "h264", "video/x-h264" },
+      { "h265", "video/x-h265" } };
+    if (pixel_format_ == "nv12") {
+      // For nv12 encoding input (raw video)
+      caps =
+          gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "NV12", "width", G_TYPE_INT,
+              1920, "height", G_TYPE_INT, 1080, "framerate", GST_TYPE_FRACTION, 30, 1, NULL);
+    } else {
+      // For decoder input (h264)
+      try {
+        caps = gst_caps_new_simple(mime_mapping.at(pixel_format_).c_str(), "stream-format",
+            G_TYPE_STRING, "byte-stream", "alignment", G_TYPE_STRING, "au", NULL);
+      } catch (const std::exception & e) {
+        RCLCPP_ERROR(this->get_logger(), "Invalid pixel format: %s", pixel_format_.c_str());
+        return;
+      }
+    }
+
+    gst_app_src_set_caps(app_src_, caps);
+    gst_caps_unref(caps);
+
+    // Connect need-data signal
+    g_signal_connect(app_src_, "need-data", G_CALLBACK(on_need_data_static), this);
+
+    // Start the pipeline
+    GstStateChangeReturn ret = gst_element_set_state(pipeline_, GST_STATE_PLAYING);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to start pipeline");
+    }
+  }
+
+  static void on_need_data_static(GstAppSrc * src, guint length, gpointer user_data)
+  {
+    static_cast<SinkNodeBase *>(user_data)->on_need_data(src, length);
+  }
+
+  void on_need_data(GstAppSrc * src, guint length)
+  {
+    // This function is called when the appsrc element needs more data
+    // We don't need to do anything here, as we push data when we receive it via
+    // ROS messages
+    RCLCPP_INFO(this->get_logger(), "Src: %s, Need %d bytes", gst_element_get_name(src), length);
+  }
+
+  uint64_t frame_counter_;
+  typename rclcpp::Subscription<MessageT>::SharedPtr subscription_;
+
+  GstAppSrc * app_src_ = nullptr;
+};
+
+/**
+ * @brief Sink node specialized for CompressedImage messages
+ */
+class CompressedWriter : public SinkNodeBase<sensor_msgs::msg::CompressedImage>
+{
+public:
+  explicit CompressedWriter(const rclcpp::NodeOptions & options)
+    : SinkNodeBase<sensor_msgs::msg::CompressedImage>("compressed_writer", options)
+  {
+  }
+
+protected:
+  struct ReleaseData
+  {
+    std::shared_ptr<sensor_msgs::msg::CompressedImage> data;
+  };
+
+  GstBuffer * extract_data(const std::shared_ptr<sensor_msgs::msg::CompressedImage> & msg) override
+  {
+    auto & data = msg->data;
+    auto release_data = new ReleaseData{ msg };
+
+    if (pixel_format_.empty()) {
+      pixel_format_ = msg->format;
+      RCLCPP_INFO(this->get_logger(), "Detected pixel format: %s", pixel_format_.c_str());
+    }
+
+    // Create a new buffer that wraps the vector's data
+    GstBuffer * buffer = gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, data.data(),
+        data.size(), 0, data.size(), release_data, [](gpointer data) {
+          if (data != nullptr) {
+            auto release_data = static_cast<ReleaseData *>(data);
+            delete release_data;
+          }
+        });
+
+    if (!buffer) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to create buffer");
+      delete release_data;
+      return nullptr;
+    }
+
+    auto stamp = msg->header.stamp;
+    GST_BUFFER_PTS(buffer) = stamp.sec * GST_SECOND + stamp.nanosec;
+
+    return buffer;
+  }
+
+private:
+};
+
+/**
+ * @brief Sink node specialized for qrb_ros::transport::type::Image messages
+ */
+class ImageWriter : public SinkNodeBase<qrb_ros::transport::type::Image>
+{
+public:
+  explicit ImageWriter(const rclcpp::NodeOptions & options)
+    : SinkNodeBase<qrb_ros::transport::type::Image>("image_writer", options)
+  {
+  }
+
+protected:
+  struct ReleaseData
+  {
+    std::shared_ptr<qrb_ros::transport::type::Image> data;
+  };
+
+  GstBuffer * extract_data(const std::shared_ptr<qrb_ros::transport::type::Image> & msg) override
+  {
+    std::map<std::string, GstVideoFormat> format_map = {
+      { "nv12", GST_VIDEO_FORMAT_NV12 },
+      { "i420", GST_VIDEO_FORMAT_I420 },
+    };
+
+    if (pixel_format_.empty()) {
+      pixel_format_ = msg->encoding;
+      RCLCPP_INFO(this->get_logger(), "Detected pixel format: %s", pixel_format_.c_str());
+    }
+
+    // Create a buffer from the dmabuf
+    GstAllocator * allocator = gst_dmabuf_allocator_new();
+    GstMemory * memory =
+        gst_dmabuf_allocator_alloc(allocator, msg->dmabuf->fd(), msg->dmabuf->size());
+
+    if (memory == nullptr) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to allocate memory");
+      return nullptr;
+    }
+
+    auto release_data = new ReleaseData{ msg };
+    gst_mini_object_set_qdata(GST_MINI_OBJECT(memory),
+        g_quark_from_string("qrb_ros::transport::type::Image"), release_data, [](gpointer data) {
+          auto release_data = static_cast<ReleaseData *>(data);
+          delete release_data;
+        });
+
+    GstBuffer * buffer = gst_buffer_new();
+    gst_buffer_append_memory(buffer, memory);
+
+    auto stamp = msg->header.stamp;
+    auto width = msg->width;
+    auto height = msg->height;
+    GstVideoFormat format = GST_VIDEO_FORMAT_UNKNOWN;
+    try {
+      format = format_map.at(msg->encoding);
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(this->get_logger(), "Invalid encoding: %s", msg->encoding.c_str());
+      return nullptr;
+    }
+    GST_BUFFER_PTS(buffer) = stamp.sec * GST_SECOND + stamp.nanosec;
+    gst_buffer_add_video_meta(buffer, GST_VIDEO_FRAME_FLAG_NONE, format, width, height);
+
+    gst_object_unref(allocator);
+
+    return buffer;
+  }
+
+private:
+};
+
+}  // namespace video
+}  // namespace qrb_ros
+
+// Register the components with class loader
+RCLCPP_COMPONENTS_REGISTER_NODE(qrb_ros::video::CompressedWriter)
+RCLCPP_COMPONENTS_REGISTER_NODE(qrb_ros::video::ImageWriter)

--- a/qrb_ros_video/test/src/src_node.cpp
+++ b/qrb_ros_video/test/src/src_node.cpp
@@ -1,0 +1,437 @@
+/*
+**************************************************************************************************
+* Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+* SPDX-License-Identifier: BSD-3-Clause-Clear
+**************************************************************************************************
+*/
+
+#include <gst/app/gstappsink.h>
+#include <gst/gst.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "base_node.hpp"
+#include "qrb_ros_transport_image_type/image.hpp"
+#include "qrb_ros_transport_image_type/image_utils.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "sensor_msgs/msg/compressed_image.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+using namespace std::chrono_literals;
+
+namespace qrb_ros
+{
+namespace video
+{
+
+// Forward declarations of specialized classes for registration
+class CompressedReader;
+class ImageReader;
+
+/**
+ * @brief Base source node template class for different message types
+ * @tparam MessageT The message type to publish
+ */
+template <typename MessageT>
+class SourceNodeBase : public BaseNode
+{
+public:
+  explicit SourceNodeBase(const std::string & node_name, const rclcpp::NodeOptions & options)
+    : BaseNode(node_name, options), duration_(this->declare_parameter("duration", "0"))
+
+  {
+    // Create publisher for output data - specific type will be set by derived
+    // class
+    publisher_ = this->create_publisher<MessageT>("output", 10);
+
+    // Create GStreamer pipeline based on mode
+    setup_pipeline();
+
+    parse_duration();
+
+    end_time_ = std::chrono::steady_clock::now() + std::chrono::seconds(duration_seconds_);
+
+    // Create timer to publish data at 1/fps interval
+    timer_ = this->create_wall_timer(std::chrono::milliseconds(static_cast<int>(1000 / fps_)),
+        std::bind(&SourceNodeBase::timer_callback, this));
+  }
+
+  ~SourceNodeBase()
+  {
+    if (!timer_->is_canceled()) {
+      timer_ = nullptr;
+      available_sample = 0;
+    }
+    // Base class will clean up GStreamer pipeline
+    if (pipeline_) {
+      // Send an EOS event to the pipeline to signal elements to finish gracefully.
+      // This event flows from the beginning of the pipeline.
+      if (!gst_element_send_event(pipeline_, gst_event_new_eos())) {
+        RCLCPP_WARN(this->get_logger(), "Failed to send EOS event to the pipeline.");
+      } else {
+        // Optionally, wait for the EOS message on the bus to confirm propagation.
+        // This gives elements time to process the EOS before we force NULL state.
+        GstBus * bus = gst_element_get_bus(pipeline_);
+        if (bus) {
+          RCLCPP_INFO(this->get_logger(),
+              "Waiting for EOS message on bus after sending event (duration stop)...");
+          GstMessage * msg = gst_bus_timed_pop_filtered(bus,
+              2 * GST_SECOND,  // Timeout for waiting (e.g., 2 seconds)
+              static_cast<GstMessageType>(GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+          if (msg) {
+            if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_EOS) {
+              RCLCPP_INFO(this->get_logger(), "EOS message received on bus (duration stop).");
+            } else if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_ERROR) {
+              GError * err = nullptr;
+              gchar * debug_info = nullptr;
+              gst_message_parse_error(msg, &err, &debug_info);
+              RCLCPP_ERROR(this->get_logger(),
+                  "Error message received on bus during EOS: %s. Debug: %s",
+                  err ? err->message : "Unknown error", debug_info ? debug_info : "None");
+              if (err)
+                g_error_free(err);
+              if (debug_info)
+                g_free(debug_info);
+            }
+            // Unref the message to free resources
+            gst_message_unref(msg);
+          } else {
+            RCLCPP_WARN(this->get_logger(),
+                "Timeout waiting for EOS on bus (duration stop). Pipeline might not have fully "
+                "processed EOS event.");
+          }
+          gst_object_unref(bus);
+        } else {
+          RCLCPP_WARN(
+              this->get_logger(), "Could not get pipeline bus to wait for EOS (duration stop).");
+        }
+      }
+      // Set pipeline to NULL state to stop and release all resources.
+      gst_element_set_state(pipeline_, GST_STATE_NULL);
+      gst_object_unref(pipeline_);
+      pipeline_ = nullptr;
+    }
+    if (app_sink_) {
+      gst_object_unref(app_sink_);
+      app_sink_ = nullptr;
+    }
+    RCLCPP_WARN(this->get_logger(), "SourceNodeBase destructor finished.");
+  }
+
+protected:
+  // Method to fill specific message type - to be implemented by derived classes
+  virtual void fill_message(typename std::unique_ptr<MessageT> & msg,
+      const uint8_t * data,
+      size_t size) = 0;
+
+  void parse_duration()
+  {
+    // Parse the duration string to seconds
+    if (duration_.empty() || duration_ == "0") {
+      duration_seconds_ = 0;
+      return;
+    }
+
+    try {
+      // Parse human-readable duration string
+      std::regex regex(R"((\d+)([smhd]))");
+      std::smatch match;
+      std::string str = duration_;
+      duration_seconds_ = 0;
+      while (std::regex_search(str, match, regex)) {
+        int value = std::stoi(match[1]);
+        char unit = match[2].str()[0];
+        switch (unit) {
+          case 's':
+            duration_seconds_ += value;
+            break;
+          case 'm':
+            duration_seconds_ += value * 60;
+            break;
+          case 'h':
+            duration_seconds_ += value * 3600;
+            break;
+          case 'd':
+            duration_seconds_ += value * 86400;
+            break;
+          default:
+            throw std::invalid_argument("Invalid duration unit");
+        }
+        str = match.suffix().str();
+      }
+    } catch (const std::invalid_argument & e) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to parse duration: %s", e.what());
+      duration_seconds_ = 0;
+    }
+  }
+
+  // Setup the GStreamer pipeline
+  const std::map<std::string, std::function<std::string()>> pipeline_template = {
+    { "nv12",
+        [this]() {
+          std::ostringstream oss;
+          oss << "filesrc location=" << url_ << " ! rawvideoparse width=" << width_
+              << " height=" << height_ << " format=nv12"
+              << " framerate=" << framerate_ << " ! appsink name=sink";
+          return oss.str();
+        } },
+    { "mp4",
+        [this]() {
+          std::ostringstream oss;
+          oss << "filesrc location=" << url_ << " ! qtdemux"
+              << " ! " << pixel_format_ << "parse ! video/x-" << pixel_format_
+              << ",stream-format=byte-stream,alignment=au"
+              << " ! appsink name=sink";
+          return oss.str();
+        } },
+    { "h264",
+        [this]() {
+          std::ostringstream oss;
+          oss << "filesrc location=" << url_
+              << " ! h264parse ! video/x-h264,stream-format=byte-stream,alignment=au ! appsink "
+                 "name=sink";
+          return oss.str();
+        } },
+    { "h265",
+        [this]() {
+          std::ostringstream oss;
+          oss << "filesrc location=" << url_
+              << " ! h265parse ! video/x-h265,stream-format=byte-stream,alignment=au ! appsink "
+                 "name=sink";
+          return oss.str();
+        } },
+  };
+
+  void setup_pipeline() override
+  {
+    std::string pipeline_str;
+    try {
+      discover_pipeline();
+      pipeline_str = pipeline_template.at(format_)();
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(
+          this->get_logger(), "Invalid format: %s. Use 'encoder' or 'decoder'", format_.c_str());
+      return;
+    }
+
+    if (!create_pipeline(pipeline_str)) {
+      return;
+    }
+
+    // Get the appsink element
+    GstElement * sink = gst_bin_get_by_name(GST_BIN(pipeline_), "sink");
+    if (!sink) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to get appsink element");
+      return;
+    }
+
+    // Configure appsink
+    app_sink_ = GST_APP_SINK(sink);
+    gst_app_sink_set_emit_signals(app_sink_, TRUE);
+    gst_app_sink_set_drop(app_sink_, FALSE);
+    gst_app_sink_set_max_buffers(app_sink_, 3);
+    gst_app_sink_set_wait_on_eos(app_sink_, FALSE);
+
+    // Connect the new-sample signal
+    g_signal_connect(app_sink_, "new-sample", G_CALLBACK(on_new_sample_static), this);
+
+    // Start the pipeline
+    GstStateChangeReturn ret = gst_element_set_state(pipeline_, GST_STATE_PLAYING);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to start pipeline");
+    }
+  }
+
+  static GstFlowReturn on_new_sample_static(GstAppSink * sink, gpointer user_data)
+  {
+    return static_cast<SourceNodeBase *>(user_data)->on_new_sample(sink);
+  }
+
+  GstFlowReturn on_new_sample(GstAppSink * sink)
+  {
+    // just keep the count of available samples
+    available_sample++;
+
+    return GST_FLOW_OK;
+  }
+
+  void timer_callback()
+  {
+    static int count = 0;  // Persistent frame counter
+
+    if (app_sink_ && available_sample > 0) {
+      if (timer_->is_canceled()) {
+        RCLCPP_ERROR(this->get_logger(), "Timer is canceled, stopping further processing.");
+        return;
+      }
+      GstSample * sample = gst_app_sink_try_pull_sample(app_sink_, 5 * GST_MSECOND);
+      if (sample) {
+        count++;
+        GstBuffer * buffer = gst_sample_get_buffer(sample);
+        GstMapInfo map;
+
+        auto msg = std::make_unique<MessageT>();
+        // Fill message header
+        auto ros_now = this->now();  // Use rclcpp::Node::now() for ROS timestamp
+        msg->header.stamp = ros_now;
+        msg->header.frame_id = std::to_string(count);
+
+        if (gst_buffer_map(buffer, &map, GST_MAP_READ)) {
+          fill_message(msg, map.data, map.size);
+          gst_buffer_unmap(buffer, &map);
+        } else {
+          RCLCPP_WARN(this->get_logger(), "Failed to map GStreamer buffer for sample processing.");
+        }
+
+        publisher_->publish(std::move(msg));
+        gst_sample_unref(sample);
+        available_sample--;  // Decrement only after successfully processing a sample
+      } else {
+        // This can happen if EOS was signaled right after on_new_sample incremented
+        // available_sample but before this timer callback could pull it.
+        RCLCPP_DEBUG(this->get_logger(),
+            "available_sample > 0 but gst_app_sink_pull_sample returned NULL. EOS might be "
+            "imminent.");
+      }
+    }
+
+    // Check for pipeline stop or loop conditions
+    auto now_steady = std::chrono::steady_clock::now();
+
+    // Condition 1: Duration for playback has been reached
+    if (duration_seconds_ > 0 && now_steady >= end_time_) {
+      RCLCPP_INFO(
+          this->get_logger(), "Duration reached. Sending EOS event and stopping the pipeline.");
+      if (timer_) {
+        timer_->cancel();
+      }
+      return;  // Stop further processing in this callback
+    }
+
+    // Condition 2: Natural End-Of-Stream from the GStreamer source
+    // This check is relevant for both play-once (duration_seconds_ == 0)
+    // and looping (duration_seconds_ > 0 but end_time_ not yet reached).
+    if (app_sink_ && gst_app_sink_is_eos(app_sink_)) {
+      // Ensure all samples signaled by on_new_sample have been processed before acting on EOS.
+      if (available_sample == 0) {
+        if (duration_seconds_ == 0) {
+          // Play once mode: Natural EOS reached, stop the pipeline.
+          RCLCPP_INFO(
+              this->get_logger(), "End of stream reached (play once mode). Stopping the pipeline.");
+          if (timer_) {
+            timer_->cancel();
+          }
+          // No need to send another EOS event; the source already signaled it.
+          return;  // Stop further processing
+        } else {
+          // Looping mode (duration_seconds_ > 0 and end_time_ not yet reached):
+          // Natural EOS reached, so seek to the beginning to loop the content.
+          RCLCPP_INFO(this->get_logger(),
+              "End of stream reached (looping mode). Seeking to the beginning.");
+          if (pipeline_) {
+            if (!gst_element_seek_simple(pipeline_, GST_FORMAT_TIME,
+                    static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE), 0)) {
+              RCLCPP_ERROR(this->get_logger(),
+                  "Failed to seek to beginning for looping. Stopping pipeline.");
+              if (timer_)
+                timer_->cancel();  // Stop trying if seek fails
+              gst_element_set_state(pipeline_, GST_STATE_NULL);
+              return;  // Stop further processing
+            }
+            // If seek is successful, the pipeline will restart sending samples from the beginning.
+          } else {
+            RCLCPP_ERROR(
+                this->get_logger(), "Pipeline is null, cannot seek for looping. Stopping timer.");
+            if (timer_)
+              timer_->cancel();
+            return;
+          }
+        }
+      }
+    }
+  }
+
+protected:
+  GstAppSink * app_sink_ = nullptr;
+
+  std::string duration_;
+  int duration_seconds_ = 0;
+  std::chrono::steady_clock::time_point end_time_;
+
+  typename rclcpp::Publisher<MessageT>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  std::mutex buffer_mutex_;
+  std::atomic<uint32_t> available_sample = 0;
+  GstClockTime buffer_timestamp_ = GST_CLOCK_TIME_NONE;
+  std::thread main_thread_;
+};
+
+/**
+ * @brief Source node specialized for CompressedImage messages
+ */
+class CompressedReader : public SourceNodeBase<sensor_msgs::msg::CompressedImage>
+{
+public:
+  explicit CompressedReader(const rclcpp::NodeOptions & options)
+    : SourceNodeBase<sensor_msgs::msg::CompressedImage>("CompressedReader", options)
+  {
+  }
+
+protected:
+  void fill_message(sensor_msgs::msg::CompressedImage::UniquePtr & msg,
+      const uint8_t * data,
+      size_t size) override
+  {
+    // Set format based on mode
+    msg->format = format_;
+
+    // Copy the data
+    msg->data.resize(size);
+    memcpy(msg->data.data(), data, size);
+  }
+};
+
+/**
+ * @brief Source node specialized for qrb_ros::transport::type::Image messages
+ */
+class ImageReader : public SourceNodeBase<qrb_ros::transport::type::Image>
+{
+public:
+  explicit ImageReader(const rclcpp::NodeOptions & options)
+    : SourceNodeBase<qrb_ros::transport::type::Image>("ImageReader", options)
+  {
+  }
+
+protected:
+  void fill_message(std::unique_ptr<qrb_ros::transport::type::Image> & msg,
+      const uint8_t * data,
+      size_t size) override
+  {
+    // Configure message based on mode
+    msg->encoding = format_;
+    msg->width = std::stoi(width_);
+    msg->height = std::stoi(height_);
+    size_t aligned_size = qrb_ros::transport::image_utils::get_image_align_size(
+        msg->width, msg->height, msg->encoding);
+    msg->dmabuf = lib_mem_dmabuf::DmaBuffer::alloc(aligned_size, "/dev/dma_heap/system");
+    if (!msg->dmabuf) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to allocate dmabuf");
+      return;
+    }
+    qrb_ros::transport::image_utils::save_image_to_dmabuf(
+        msg->dmabuf, data, msg->width, msg->height, msg->width, msg->encoding, true);
+    msg->dmabuf->set_auto_release(true);
+  }
+};
+
+}  // namespace video
+}  // namespace qrb_ros
+
+// Register the components with class loader
+RCLCPP_COMPONENTS_REGISTER_NODE(qrb_ros::video::CompressedReader)
+RCLCPP_COMPONENTS_REGISTER_NODE(qrb_ros::video::ImageReader)

--- a/qrb_video_v4l2_lib/CMakeLists.txt
+++ b/qrb_video_v4l2_lib/CMakeLists.txt
@@ -13,6 +13,16 @@ pkg_check_modules(glog REQUIRED libglog)
 set(INCLUDE_DIRS ${glog_INCLUDE_DIRS})
 
 include_directories(${INCLUDE_DIRS})
+add_compile_options(
+  -Wall
+  -Wpedantic
+  -Werror
+  -Wno-unused-parameter
+  -Wno-unused-variable
+  -Wno-unused-function
+  -Wno-unused-value
+  -std=c++17
+)
 
 file(GLOB SOURCES src/utils/*.cpp src/*.cpp src/v4l2/*.cpp)
 

--- a/qrb_video_v4l2_lib/include/Memory.hpp
+++ b/qrb_video_v4l2_lib/include/Memory.hpp
@@ -42,7 +42,7 @@ struct Memory
   };
 
   explicit Memory(const std::shared_ptr<Allocation> & allocation)
-    : base(nullptr), allocation(allocation)
+    : allocation(allocation), base(nullptr)
   {
   }
 
@@ -118,7 +118,7 @@ struct MemoryView
     return view;
   }
 
-  uint32_t determinePlanes()
+  void determinePlanes()
   {
     switch (pixelfmt) {
       case Format::NV12: {

--- a/qrb_video_v4l2_lib/include/utils/Log.hpp
+++ b/qrb_video_v4l2_lib/include/utils/Log.hpp
@@ -75,9 +75,7 @@ public:
   {
     const int n = vsnprintf(nullptr, 0, fmt, args);
     std::string s;
-    if (s.capacity() < n) {
-      s.reserve(n);
-    }
+    s.reserve(n);
     s.resize(n);
     vsnprintf(s.data(), n + 1, fmt, args);
 
@@ -85,9 +83,9 @@ public:
   }
 };
 
-#define LOGI(fmt, ...) Log::logInfo(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
-#define LOGW(fmt, ...) Log::logWarning(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
-#define LOGE(fmt, ...) Log::logError(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
+#define LOGI(...) Log::logInfo(__FILE__, __LINE__, __VA_ARGS__)
+#define LOGW(...) Log::logWarning(__FILE__, __LINE__, __VA_ARGS__)
+#define LOGE(...) Log::logError(__FILE__, __LINE__, __VA_ARGS__)
 
 }  // namespace qrb::video_v4l2
 

--- a/qrb_video_v4l2_lib/include/v4l2/V4l2Codec.hpp
+++ b/qrb_video_v4l2_lib/include/v4l2/V4l2Codec.hpp
@@ -8,11 +8,11 @@
 #ifndef QRB_VIDEO_V4L2__V4L2CODEC_HPP_
 #define QRB_VIDEO_V4L2__V4L2CODEC_HPP_
 
+#include <array>
 #include <linux/v4l2_vidc_extensions.hpp>
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <array>
 
 #include "BufferChannel.hpp"
 #include "BufferPool.hpp"
@@ -84,11 +84,11 @@ public:
   bool onV4l2Error(error_t error) override;
 
 protected:
-  static const std::unordered_map<uint32_t, uint32_t> avcProfileMapping;
-  static const std::unordered_map<uint32_t, uint32_t> hevcProfileMapping;
-  static const std::unordered_map<uint32_t, uint32_t> avcLevelMapping;
-  static const std::unordered_map<uint32_t, uint32_t> hevcLevelMapping;
-  static const std::unordered_map<Bitrate::Mode, uint32_t> bitrateModeMapping;
+  static const std::unordered_map<uint32_t, int32_t> avcProfileMapping;
+  static const std::unordered_map<uint32_t, int32_t> hevcProfileMapping;
+  static const std::unordered_map<uint32_t, int32_t> avcLevelMapping;
+  static const std::unordered_map<uint32_t, int32_t> hevcLevelMapping;
+  static const std::unordered_map<Bitrate::Mode, int32_t> bitrateModeMapping;
   static const std::unordered_map<Format, uint32_t> formatMapping;
 
   CodecType type;

--- a/qrb_video_v4l2_lib/src/BufferChannel.cpp
+++ b/qrb_video_v4l2_lib/src/BufferChannel.cpp
@@ -25,7 +25,6 @@ std::shared_ptr<Buffer> BufferChannel::acquireBuffer()
   auto msg = this->obtainMessage(MSG_ACQUIRE_BUFFER);
   msg->data = std::shared_ptr<Buffer>();
   this->sendMessage(msg);
-  LOGI("send msg %d with %s", MSG_ACQUIRE_BUFFER, msg->data);
   return std::any_cast<std::shared_ptr<Buffer> >(msg->data);
 }
 

--- a/qrb_video_v4l2_lib/src/utils/Handler.cpp
+++ b/qrb_video_v4l2_lib/src/utils/Handler.cpp
@@ -48,7 +48,12 @@ int32_t Handler::sendMessage(std::shared_ptr<Message> & message)
   if (message->flags & Flags::SYNC) {
     LOGI("wait for msg done");
     auto future = message->promise.get_future();
-    result = future.get();
+    if (future.wait_for(std::chrono::milliseconds(100)) == std::future_status::ready) {
+      result = future.get();
+    } else {
+      LOGE("wait for msg done timeout");
+      result = 0;
+    }
   }
 
   return result;

--- a/qrb_video_v4l2_lib/src/v4l2/V4l2Driver.cpp
+++ b/qrb_video_v4l2_lib/src/v4l2/V4l2Driver.cpp
@@ -8,7 +8,6 @@
 #include "V4l2Driver.hpp"
 
 #include <fcntl.h>
-#include <linux/v4l2_vidc_extensions.hpp>
 #include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -16,6 +15,8 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <functional>
+#include <linux/v4l2_vidc_extensions.hpp>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -112,7 +113,7 @@ void V4l2Driver::start()
 {
   if (not pollThread.joinable()) {
     pollThreadRunning = true;
-    pollThread = std::thread(std::mem_fun(&V4l2Driver::threadLoop), this);
+    pollThread = std::thread(std::mem_fn(&V4l2Driver::threadLoop), this);
   }
   LOGI("poll thread started");
 }

--- a/qrb_video_v4l2_lib/src/v4l2/V4l2Memory.cpp
+++ b/qrb_video_v4l2_lib/src/v4l2/V4l2Memory.cpp
@@ -24,12 +24,11 @@ DmabufAllocator::~DmabufAllocator()
 
 std::shared_ptr<Allocation> DmabufAllocator::allocate()
 {
-  struct dma_heap_allocation_data data = {
-    .len = view.planes[0].size,
-    .fd = 0,
-    .fd_flags = O_RDWR | O_CLOEXEC,
-    .heap_flags = 0,
-  };
+  struct dma_heap_allocation_data data = {};
+  data.len = view.planes[0].size;
+  data.fd = 0;
+  data.fd_flags = O_RDWR | O_CLOEXEC;
+  data.heap_flags = 0;
   if (::ioctl(fd, DMA_HEAP_IOCTL_ALLOC, &data) < 0) {
     throw std::runtime_error("Failed to allocate buffer");
   }


### PR DESCRIPTION
Provide 2 changes about qrb_ros_video:

qrb_ros_video: Enhance CMake configuration and improve code quality
- Added compiler flags for stricter warnings and error handling in CMakeLists.txt.
- Refactored Memory constructor initialization order for clarity.
- Optimized Log class string handling by reserving memory upfront.
- Changed unordered_map types from uint32_t to int32_t for better compatibility.
- Updated thread handling in V4l2Driver to use std::mem_fn.
- Simplified dma_heap_allocation_data initialization in V4l2Memory.

qrb_ros_video: Add GStreamer-based test nodes and update CMake configuration
- Introduced new test nodes for video processing: CompressedReader, ImageReader, CompressedWriter, and ImageWriter.
- Updated CMakeLists.txt to include GStreamer dependencies and added a test components library.
- Created README.md for test nodes detailing available nodes, parameters, and usage instructions.
- Implemented base node class for GStreamer integration and established message handling for ROS2 topics.
