### PR TITLE
fix: qrb_ros_video: video processing with framerate handling

### DIFF
--- a/qrb_ros_video/CMakeLists.txt
+++ b/qrb_ros_video/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(ros2video_component PUBLIC
 target_compile_features(ros2video_component PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 target_link_directories(ros2video_component PRIVATE $<TARGET_LINKER_FILE_DIR:v4l2codecs>)
 set_target_properties(ros2video_component PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION 1)
-target_link_libraries(ros2video_component lib_mem_dmabuf qrb_ros_transport_image_type v4l2codecs)
+target_link_libraries(ros2video_component v4l2codecs)
 ament_target_dependencies(
   ros2video_component
   "std_msgs"

--- a/qrb_ros_video/include/video_node.hpp
+++ b/qrb_ros_video/include/video_node.hpp
@@ -53,6 +53,7 @@ protected:
   std::string pixel_format;
   std::string format;
   std::string log_level;
+  std::atomic<uint64_t> seqno = 0;
 
   typename rclcpp::Subscription<InputMessageT>::SharedPtr subscription;
   typename rclcpp::Publisher<OutputMessageT>::SharedPtr publisher;

--- a/qrb_ros_video/package.xml
+++ b/qrb_ros_video/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>qrb_ros_video</name>
-  <version>0.0.1</version>
+  <version>0.1.0</version>
   <description>TODO: Package description</description>
   <maintainer email="quic_jianxiao@quicinc.com">Jean Xiao</maintainer>
   <license>BSD-3-Clause-Clear</license>
@@ -13,7 +13,7 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>rclcpp</depend>
-  <depend>image_transport</depend>
+  <depend>lib_mem_dmabuf</depend>
   <depend>rclcpp_components</depend>
   <depend>ros2launch</depend>
   <depend>qrb_video_v4l2_lib</depend>

--- a/qrb_ros_video/src/video_decoder.cpp
+++ b/qrb_ros_video/src/video_decoder.cpp
@@ -44,6 +44,7 @@ public:
   bool onBufferAvailable(const std::shared_ptr<Buffer> & item) override
   {
     RCLCPP_DEBUG(this->get_logger(), "received output buffer: [%ld]", item->index);
+    this->seqno++;
     publish_message_<Type>(item);
     RCLCPP_DEBUG(this->get_logger(), "output buffer: [%ld] publish completed", item->index);
     return true;
@@ -129,7 +130,7 @@ protected:
     auto msg = std::make_unique<Type>();
     msg->header.stamp.sec = item->timestamp.tv_sec;
     msg->header.stamp.nanosec = item->timestamp.tv_usec * 1000L;
-    // msg->header.set__frame_id(item->sequence);
+    msg->header.frame_id = std::to_string(this->seqno);
     auto view = item->view();
     msg->width = view.width;
     msg->height = view.height;

--- a/qrb_ros_video/test/include/base_node.hpp
+++ b/qrb_ros_video/test/include/base_node.hpp
@@ -51,7 +51,9 @@ public:
       denominator = framerate_.substr(pos + 1);
     }
     std::string numerator = framerate_.substr(0, pos);
-    fps_ = std::stof(numerator) / std::stof(denominator);
+    if (std::stof(denominator) != 0) {
+      fps_ = std::stof(numerator) / std::stof(denominator);
+    }
 
     // Set ROS Node log level
     auto log_level = rclcpp::Logger::Level::Warn;
@@ -179,9 +181,13 @@ protected:
           gint fps_denom = gst_discoverer_video_info_get_framerate_denom(video_info);
 
           // Avoid division by zero
-          if (fps_denom > 0) {
-            framerate_ = std::to_string(fps_num) + "/" + std::to_string(fps_denom);
-            fps_ = static_cast<float>(fps_num) / static_cast<float>(fps_denom);
+          if (fps_denom > 0 && fps_num > 0) {
+            auto framerate = std::to_string(fps_num) + "/" + std::to_string(fps_denom);
+            auto fps = static_cast<float>(fps_num) / static_cast<float>(fps_denom);
+            if (fps != fps_) {
+              RCLCPP_WARN(this->get_logger(),
+                  "Detected framerate: %s (%f fps)", framerate.c_str(), fps);
+            }
           }
 
           RCLCPP_INFO(this->get_logger(), "Video properties: %sx%s @ %s fps", width_.c_str(),

--- a/qrb_ros_video/test/src/src_node.cpp
+++ b/qrb_ros_video/test/src/src_node.cpp
@@ -59,6 +59,7 @@ public:
     // Create timer to publish data at 1/fps interval
     timer_ = this->create_wall_timer(std::chrono::milliseconds(static_cast<int>(1000 / fps_)),
         std::bind(&SourceNodeBase::timer_callback, this));
+    RCLCPP_INFO(this->get_logger(), "live source at fps %f", fps_);
   }
 
   ~SourceNodeBase()
@@ -279,7 +280,7 @@ protected:
         // Fill message header
         auto ros_now = this->now();  // Use rclcpp::Node::now() for ROS timestamp
         msg->header.stamp = ros_now;
-        msg->header.frame_id = std::to_string(count);
+        msg->header.frame_id = std::to_string(count) + "@" + framerate_;
 
         if (gst_buffer_map(buffer, &map, GST_MAP_READ)) {
           fill_message(msg, map.data, map.size);

--- a/qrb_video_v4l2_lib/include/linux/v4l2_vidc_extensions.hpp
+++ b/qrb_video_v4l2_lib/include/linux/v4l2_vidc_extensions.hpp
@@ -5,6 +5,8 @@
 **************************************************************************************************
 */
 
+#include <linux/v4l2-controls.h>
+
 #ifndef V4L2_VIDC_EXTENSIONS_HPP_
 #define V4L2_VIDC_EXTENSIONS_HPP_
 
@@ -26,6 +28,17 @@
 
 #ifndef V4L2_BUF_FLAG_CODECCONFIG
 #define V4L2_BUF_FLAG_CODECCONFIG 0x01000000
+#endif
+
+#ifdef V4L2_CTRL_CLASS_CODEC
+#define V4L2_CID_MPEG_VIDC_BASE (V4L2_CTRL_CLASS_CODEC | 0x2000)
+#else
+#define V4L2_CID_MPEG_VIDC_BASE (V4L2_CTRL_CLASS_MPEG | 0x2000)
+#endif
+
+#ifndef V4L2_CID_MPEG_VIDC_VUI_TIMING_INFO
+#define V4L2_CID_MPEG_VIDC_VUI_TIMING_INFO                                    \
+    (V4L2_CID_MPEG_VIDC_BASE + 0x43)
 #endif
 
 #endif  // V4L2_VIDC_EXTENSIONS_HPP_

--- a/qrb_video_v4l2_lib/src/v4l2/V4l2Encoder.cpp
+++ b/qrb_video_v4l2_lib/src/v4l2/V4l2Encoder.cpp
@@ -63,6 +63,11 @@ bool V4l2Encoder::start()
   v4l2_encoder_cmd cmd = {};
   cmd.cmd = V4L2_ENC_CMD_START;
   driver->encCommand(&cmd) == 0;
+
+  v4l2_control ctrl = {};
+  ctrl.id = V4L2_CID_MPEG_VIDC_VUI_TIMING_INFO;
+  ctrl.value = 1;  // Enable VUI timing info
+  driver->setControl(&ctrl);
   return V4l2Codec::start();
 }
 


### PR DESCRIPTION
It's for test purpose of generating mp4 file. Frame rate should be handled and passed to sink_node to let qtmux generate correct metadata.
At same time, enable vui time info by default for encoder.